### PR TITLE
Use plainer English instead of 'editorialize'

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -81,10 +81,10 @@ See the guidelines below for more." %>
         <ul>
 
           <li><p>
-          Do not editorialize story titles, but when the original story's
-          title has no context or is unclear, please change it.  <strong>Please
-          remove extraneous components from titles such as the name of the
-          site, blog, section, and author.</strong>
+          When the original story's title has no context or is unclear,
+          please make it clearer; but take care to keep your opinion out of
+          it.  <strong>Please remove extraneous components from titles
+          such as the name of the site, blog, section, and author.</strong>
           </p></li>
 
           <li><p>


### PR DESCRIPTION
This change intends two things:

- more clearly empower users to improve unclear story titles
- more clearly warn users not to inject their opinion if they alter the title

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
